### PR TITLE
fixed issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,4 +21,5 @@ jobs:
 
             cd /home/ubuntu/project/infra
             docker compose -f docker-compose.prod.yml down
-            docker compose -f docker-compose.prod.yml up -d --build
+            docker compose -f docker-compose.prod.yml build --no-cache
+            docker compose -f docker-compose.prod.yml up -d


### PR DESCRIPTION
## Summary by Sourcery

Deployment:
- Change deployment script to run a no-cache Docker image build instead of `docker compose up` with build in the production workflow.