### PR TITLE
fixed issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ubuntu
           key: ${{ secrets.EC2_SSH_KEY }}
+          command_timeout: 30m
           script: |
             cd /home/ubuntu/project/SafeKeyz-Frontend
             git pull origin main

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:20-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
-RUN npm install
+RUN npm ci
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
## Summary by Sourcery

Use npm ci in the Docker build and increase the SSH deployment step timeout in the GitHub Actions workflow.

Build:
- Switch the Docker image build to use npm ci instead of npm install for installing dependencies.

CI:
- Extend the SSH deploy job in GitHub Actions with an explicit 30-minute command timeout.